### PR TITLE
create and use an IoStrategy

### DIFF
--- a/src/failingiostream.rs
+++ b/src/failingiostream.rs
@@ -1,0 +1,137 @@
+use std::io::{Read, Write, Result, Error, ErrorKind};
+
+/// `FailingIoStream` mocks a stream which will fail upon read or write
+///
+/// # Examples
+///
+/// ```
+/// use std::io::{Cursor, Read};
+///
+/// struct CountIo {}
+///
+/// impl CountIo {
+///     fn read_data(&self, r: &mut Read) -> usize {
+///         let mut count: usize = 0;
+///         let mut retries = 3;
+///
+///         loop {
+///             let mut buffer = [0; 5];
+///             match r.read(&mut buffer) {
+///                 Err(_) => {
+///                     if retries == 0 { break; }
+///                     retries -= 1;
+///                 },
+///                 Ok(0) => break,
+///                 Ok(n) => count += n,
+///             }
+///         }
+///         count
+///     }
+/// }
+///
+/// #[test]
+/// fn test_io_retries() {
+///     let mut c = Cursor::new(&b"1234"[..])
+///             .chain(FailingIoStream::new(ErrorKind::Other, "Failing", 3))
+///             .chain(Cursor::new(&b"5678"[..]));
+///
+///     let sut = CountIo {};
+///     // this will fail unless read_data performs at least 3 retries on I/O errors
+///     assert_eq!(8, sut.read_data(&mut c));
+/// }
+/// ```
+#[derive(Clone)]
+pub struct FailingIoStream {
+    kind: ErrorKind,
+    message: &'static str,
+    repeat_count: i32,
+}
+
+impl FailingIoStream {
+    /// Creates a FailingIoStream
+    ///
+    /// When `read` or `write` is called, it will return an error `repeat_count` times.
+    /// `kind` and `message` can be specified to define the exact error.
+    pub fn new(kind: ErrorKind, message: &'static str, repeat_count: i32) -> FailingIoStream {
+        FailingIoStream { kind: kind, message: message, repeat_count: repeat_count, }
+    }
+
+    fn error(&mut self) -> Result<usize> {
+        if self.repeat_count == 0 {
+            return Ok(0)
+        }
+        else {
+            if self.repeat_count > 0 {
+                self.repeat_count -= 1;
+            }
+            Err(Error::new(self.kind, self.message))
+        }
+    }
+}
+
+impl Read for FailingIoStream {
+    fn read(&mut self, _: &mut [u8]) -> Result<usize> {
+        self.error()
+    }
+}
+
+impl Write for FailingIoStream {
+    fn write(&mut self, _: &[u8]) -> Result<usize> {
+        self.error()
+    }
+
+    fn flush(&mut self) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::FailingIoStream;
+    use std::io::{Cursor, Read, Write, ErrorKind};
+    use std::error::Error;
+
+    #[test]
+    fn test_failing_mock_stream_read() {
+        let mut s = FailingIoStream::new(ErrorKind::BrokenPipe, "The dog ate the ethernet cable", 1);
+        let mut v = [0; 4];
+        let error = s.read(v.as_mut()).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::BrokenPipe);
+        assert_eq!(error.description(), "The dog ate the ethernet cable");
+        // after a single error, it will return Ok(0)
+        assert_eq!(s.read(v.as_mut()).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_failing_mock_stream_chain() {
+        let mut c = Cursor::new(&b"abcd"[..])
+                .chain(FailingIoStream::new(ErrorKind::Other, "Failing", -1));
+
+        let mut v = [0; 8];
+        assert_eq!(c.read(v.as_mut()).unwrap(), 4);
+        assert_eq!(c.read(v.as_mut()).unwrap_err().kind(), ErrorKind::Other);
+        assert_eq!(c.read(v.as_mut()).unwrap_err().kind(), ErrorKind::Other);
+    }
+
+    #[test]
+    fn test_failing_mock_stream_chain_interrupted() {
+        let mut c = Cursor::new(&b"abcd"[..])
+                .chain(FailingIoStream::new(ErrorKind::Interrupted, "Interrupted", 5))
+                .chain(Cursor::new(&b"ABCD"[..]));
+
+        let mut v = [0; 8];
+        c.read_exact(v.as_mut()).unwrap();
+        assert_eq!(v, [0x61, 0x62, 0x63, 0x64, 0x41, 0x42, 0x43, 0x44]);
+        assert_eq!(c.read(v.as_mut()).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_failing_mock_stream_write() {
+        let mut s = FailingIoStream::new(ErrorKind::PermissionDenied, "Access denied", -1);
+        let error = s.write("abcd".as_bytes()).unwrap_err();
+        assert_eq!(error.kind(), ErrorKind::PermissionDenied);
+        assert_eq!(error.description(), "Access denied");
+        // it will keep failing
+        assert!(s.write("abcd".as_bytes()).is_err());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,11 +17,15 @@
 //!     println!("{}", line.unwrap());
 //! }
 //! ```
-use std::fs::File;
 use std::io;
-use std::io::{Read, stdin};
+use std::io::Read;
 use std::borrow::Borrow;
 
+pub mod strategy;
+
+use self::strategy::{
+    IoStrategy, DefaultIoStrategy,
+};
 
 /// A file source.
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -55,19 +59,41 @@ struct State {
 }
 
 /// A wrapper which reads from multiple streams.
-pub struct FileInput {
+pub struct FileInput<Io = DefaultIoStrategy> {
     sources: Vec<Source>,
     state: Option<State>,
+    io_strat: Io,
 }
 
-impl FileInput {
-    /// Constructs a new `FileInput` that will read from the files specified.
+impl FileInput<DefaultIoStrategy> {
+    /// Constructs a new `FileInput` that will read from the files specified
+    /// with default strategies.
     pub fn new<T>(paths: &[T]) -> Self
+        where T: Borrow<str>
+    {
+        Self::with_strategies(paths, Default::default())
+    }
+}
+
+impl<Io: IoStrategy> FileInput<Io> {
+    /// Constructs a new `FileInput` that will read from the files specified
+    /// with the given `IoStrategy`.
+    pub fn with_strategies<T>(paths: &[T], io: Io) -> Self
         where T: Borrow<str>
     {
         FileInput {
             sources: make_source_vec(paths),
             state: None,
+            io_strat: io,
+        }
+    }
+
+    /// Apply a new `IoStrategy` to this `FileInput`, returning the transformed type.
+    pub fn io_strategy<Io_: IoStrategy>(self, io: Io_) -> FileInput<Io_> {
+        FileInput {
+            sources: self.sources,
+            state: self.state,
+            io_strat: io,
         }
     }
 
@@ -82,8 +108,8 @@ impl FileInput {
     fn open_next_file(&mut self) -> io::Result<()> {
         let next_source = self.sources.remove(0);
         let reader: Box<Read> = match &next_source {
-            &Source::Stdin => Box::new(stdin()),
-            &Source::File(ref path) => Box::new(try!(File::open(path))),
+            &Source::Stdin => self.io_strat.stdin(),
+            &Source::File(ref path) => try!(self.io_strat.open(path)),
         };
 
         self.state = Some(State {
@@ -95,7 +121,7 @@ impl FileInput {
     }
 }
 
-impl Read for FileInput {
+impl<Io: IoStrategy> Read for FileInput<Io> {
     fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
         loop {
             if self.state.is_none() {
@@ -117,6 +143,9 @@ impl Read for FileInput {
         }
     }
 }
+
+#[cfg(test)]
+mod failingiostream;
 
 #[cfg(test)]
 mod test {
@@ -209,6 +238,90 @@ mod test {
             let result = fileinput.read_to_string(&mut buffer);
 
             assert_eq!(result.unwrap_err().kind(), ErrorKind::NotFound);
+        }
+
+        #[test]
+        fn no_error_on_empty_files() {
+            let paths = vec!["testdata/empty", "testdata/empty"];
+            let mut fileinput = FileInput::new(&paths);
+            let mut buffer = String::new();
+
+            fileinput.read_to_string(&mut buffer).unwrap();
+
+            assert_eq!(buffer, "");
+            assert_eq!(fileinput.source(), None);
+        }
+    }
+
+    mod errors {
+        use super::super::*;
+        use super::super::strategy::IoStrategy;
+        use super::super::failingiostream::FailingIoStream;
+        use std;
+        use std::ffi::OsStr;
+        use std::io::{Read, ErrorKind};
+
+        #[derive(Debug, Default)]
+        struct FailingIo {}
+
+        impl IoStrategy for FailingIo {
+            /// If the filename of the file to open is "ERROR", it will return a mock.
+            ///
+            /// The mock will fail twice if read is called. All subsequent calls will
+            /// return `Ok(0)`.
+            fn open<P: AsRef<std::path::Path>>(&self, path: P) -> std::io::Result<Box<std::io::Read>> {
+                if path.as_ref().file_name() == Some(OsStr::new("ERROR")) {
+                    Ok(Box::new(FailingIoStream::new(ErrorKind::InvalidData, "file", 2)))
+                }
+                else {
+                    Ok(Box::new(try!(std::fs::File::open(path))))
+                }
+            }
+
+            /// Will return a mock which will fail twice if read is called.
+            ///
+            /// All subsequent calls will return `Ok(0)`.
+            fn stdin(&self) -> Box<std::io::Read> {
+                Box::new(FailingIoStream::new(ErrorKind::InvalidInput, "stdin", 2))
+            }
+        }
+
+        #[test]
+        fn read_file_failing_read() {
+            let paths = vec!["testdata/ERROR", "testdata/1"];
+            let mut fileinput = FileInput::new(&paths).io_strategy(FailingIo{});
+            let mut buffer = [0; 5];
+
+            assert_eq!(fileinput.read(&mut buffer).unwrap_err().kind(), ErrorKind::InvalidData);
+            assert_eq!(fileinput.read(&mut buffer).unwrap_err().kind(), ErrorKind::InvalidData);
+            assert_eq!(fileinput.read(&mut buffer).unwrap(), 5);
+            assert_eq!(buffer, "One.\n".as_bytes());
+        }
+
+        #[test]
+        fn read_stdin_failing_read() {
+            let paths = vec!["-", "testdata/1"];
+            let mut fileinput = FileInput::new(&paths).io_strategy(FailingIo{});
+            let mut buffer = [0; 5];
+
+            assert_eq!(fileinput.read(&mut buffer).unwrap_err().kind(), ErrorKind::InvalidInput);
+            assert_eq!(fileinput.read(&mut buffer).unwrap_err().kind(), ErrorKind::InvalidInput);
+            assert_eq!(fileinput.read(&mut buffer).unwrap(), 5);
+            assert_eq!(buffer, "One.\n".as_bytes());
+        }
+
+        #[test]
+        fn read_file_fail_after_successfull_read() {
+            let paths = vec!["testdata/1", "testdata/ERROR", "testdata/NOPE"];
+            let mut fileinput = FileInput::new(&paths).io_strategy(FailingIo{});
+            let mut buffer = [0; 10];
+
+            assert_eq!(fileinput.read(&mut buffer).unwrap(), 5);
+            assert_eq!(buffer, "One.\n\0\0\0\0\0".as_bytes());
+            assert_eq!(fileinput.read(&mut buffer).unwrap_err().kind(), ErrorKind::InvalidData);
+            assert_eq!(fileinput.read(&mut buffer).unwrap_err().kind(), ErrorKind::InvalidData);
+            assert_eq!(fileinput.read(&mut buffer).unwrap_err().kind(), ErrorKind::NotFound);
+            assert_eq!(fileinput.read(&mut buffer).unwrap(), 0);
         }
     }
 }

--- a/src/strategy.rs
+++ b/src/strategy.rs
@@ -1,0 +1,28 @@
+//! Types which can be used to tune the behavior of `FileInput`.
+//!
+//! A default strategy is provided.
+
+use std;
+use std::fmt;
+
+pub type DefaultIoStrategy = IoUseStd;
+
+#[derive(Debug, Default)]
+pub struct IoUseStd;
+
+pub trait IoStrategy: Default + fmt::Debug {
+    fn open<P: AsRef<std::path::Path>>(&self, path: P) -> std::io::Result<Box<std::io::Read>>;
+    fn stdin(&self) -> Box<std::io::Read>;
+}
+
+impl IoStrategy for IoUseStd {
+    #[inline]
+    fn open<P: AsRef<std::path::Path>>(&self, path: P) -> std::io::Result<Box<std::io::Read>> {
+        Ok(Box::new(try!(std::fs::File::open(path))))
+    }
+
+    #[inline]
+    fn stdin(&self) -> Box<std::io::Read> {
+        Box::new(std::io::stdin())
+    }
+}


### PR DESCRIPTION
Sorry for the long delay. (So feel free to take as much time as you need to review this  :wink: ).

This pull request is basically meant for comments - a first step of what I explained in #2. 

I used the same structure as [buf_redux](https://github.com/abonander/buf_redux) does for creating a strategy to open a file or stdin. Including a default, which will keep the current behaviour. Existing code should not need to be modified with these changes. 

I also added unit tests which document the current behaviour in detail. (I focussed on I/O errors). My goal here is to make sure later changes do not change this. But you have to decide whether this really needs to be documented, or is considered an implementation detail or undefined behaviour. 
